### PR TITLE
Add continuous integration workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,223 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  BUILD_DIR: _build
+  PIP_PACKAGES: >-
+    meson==0.58.0
+    cmake
+    ninja
+    gcovr
+  MACOS_BASEKIT_URL: >-
+    https://registrationcenter-download.intel.com/akdlm/irc_nas/17969/m_BaseKit_p_2021.3.0.3043.dmg
+  MACOS_HPCKIT_URL: >-
+    https://registrationcenter-download.intel.com/akdlm/irc_nas/17890/m_HPCKit_p_2021.3.0.3226_offline.dmg
+  LINUX_INTEL_COMPONENTS: >-
+    intel-oneapi-compiler-fortran
+    intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+    intel-oneapi-mkl
+    intel-oneapi-mkl-devel
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        build: [meson]
+        build-type: [debug]
+        compiler: [intel]
+        version: [2021]
+
+    env:
+      FC: ${{ matrix.compiler == 'intel' && 'ifort' || 'gfortran' }}
+      CC: ${{ matrix.compiler == 'intel' && 'icc' || 'gcc' }}
+      GCC_V: ${{ matrix.version }}
+      OMP_NUM_THREADS: 1,2,1
+      PYTHON_V: 3.8
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ env.PYTHON_V }}
+
+    - name: Install GCC (OSX)
+      if: ${{ contains(matrix.os, 'macos') && matrix.compiler == 'gnu' }}
+      run: |
+          brew install gcc@${{ env.GCC_V }}
+          ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
+          which gfortran-${GCC_V}
+          which gfortran
+
+    - name: Install GCC (Linux)
+      if: ${{ contains(matrix.os, 'ubuntu') && matrix.compiler == 'gnu' }}
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get update
+        sudo apt-get install -y gcc-${{ env.GCC_V}} gfortran-${{ env.GCC_V }}
+        sudo update-alternatives \
+        --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_V }} 100 \
+        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${{ env.GCC_V }} \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_V }}
+
+    - name: Install GCC (Windows)
+      if: ${{ contains(matrix.os, 'windows') && matrix.compiler == 'gnu' }}
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: false
+        install: >-
+          git
+          mingw-w64-x86_64-gcc-fortran
+          mingw-w64-x86_64-openblas
+          mingw-w64-x86_64-lapack
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-meson
+          mingw-w64-x86_64-ninja
+
+    - name: Prepare for cache restore
+      if: ${{ matrix.compiler == 'intel' }}
+      run: |
+        sudo mkdir -p /opt/intel
+        sudo chown $USER /opt/intel
+
+    - name: Cache Intel install
+      if: ${{ matrix.compiler == 'intel' }}
+      id: cache-install
+      uses: actions/cache@v2
+      with:
+        path: /opt/intel/oneapi
+        key: install-${{ matrix.compiler }}-${{ matrix.version }}-${{ matrix.os }}
+
+    - name: Install Intel (Linux)
+      if: ${{ contains(matrix.os, 'ubuntu') && contains(matrix.compiler, 'intel') && steps.cache-install.outputs.cache-hit != 'true' }}
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/${{ env.KEY }}
+        sudo apt-key add ${{ env.KEY }}
+        rm ${{ env.KEY }}
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install ${{ env.PKG }}
+      env:
+        KEY: GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        PKG: ${{ env.LINUX_INTEL_COMPONENTS }}
+
+    - name: Install Intel BaseKit (OSX)
+      if: ${{ contains(matrix.os, 'macos') && contains(matrix.compiler, 'intel') && steps.cache-install.outputs.cache-hit != 'true' }}
+      run: |
+        curl --output ${{ env.OUT }} --url "$URL" --retry 5 --retry-delay 5
+        hdiutil attach ${{ env.OUT }}
+        if [ -z "$COMPONENTS" ]; then
+          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=.
+          installer_exit_code=$?
+        else
+          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --continue-with-optional-error=yes --log-dir=.
+          installer_exit_code=$?
+        fi
+        hdiutil detach /Volumes/"$(basename "$URL" .dmg)" -quiet
+        exit $installer_exit_code
+      env:
+        OUT: webimage-base.dmg
+        URL: ${{ env.MACOS_BASEKIT_URL }}
+        COMPONENTS: intel.oneapi.mac.mkl.devel
+
+    - name: Install Intel HPCKit (OSX)
+      if: ${{ contains(matrix.os, 'macos') && contains(matrix.compiler, 'intel') && steps.cache-install.outputs.cache-hit != 'true' }}
+      run: |
+        curl --output ${{ env.OUT }} --url "$URL" --retry 5 --retry-delay 5
+        hdiutil attach ${{ env.OUT }}
+        if [ -z "$COMPONENTS" ]; then
+          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=.
+          installer_exit_code=$?
+        else
+          sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --continue-with-optional-error=yes --log-dir=.
+          installer_exit_code=$?
+        fi
+        hdiutil detach /Volumes/"$(basename "$URL" .dmg)" -quiet
+        exit $installer_exit_code
+      env:
+        OUT: webimage-hpc.dmg
+        URL: ${{ env.MACOS_HPCKIT_URL }}
+        COMPONENTS: all
+
+    - name: Setup Intel oneAPI environment
+      if: ${{ matrix.compiler == 'intel' }}
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Install build and test dependencies
+      if: ${{ ! contains(matrix.os, 'windows') }}
+      run: pip3 install ${{ env.PIP_PACKAGES }} ${{ env.PIP_EXTRAS }}
+
+    - name: Configure build (meson)
+      if: ${{ matrix.build == 'meson' }}
+      run: >-
+        meson setup ${{ env.BUILD_DIR }}
+        --buildtype=debug
+        --prefix=$PWD/_dist
+        --libdir=lib
+        --warnlevel=0
+        -Db_coverage=${{ env.COVERAGE }}
+        ${{ env.MESON_ARGS }}
+      env:
+        COVERAGE: ${{ matrix.build-type == 'coverage' }}
+        MESON_ARGS: ${{ matrix.compiler == 'intel' && '-Dfortran_link_args=-qopenmp' || '' }}
+
+    - name: Configure build (CMake)
+      if: ${{ matrix.build == 'cmake' }}
+      run: >-
+        cmake -B${{ env.BUILD_DIR }}
+        -GNinja
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_INSTALL_PREFIX=$PWD/_dist
+        -DCMAKE_INSTALL_LIBDIR=lib
+
+    - name: Build library
+      run: ninja -C ${{ env.BUILD_DIR }}
+
+    - name: Run unit tests
+      if: ${{ matrix.build == 'meson' }}
+      run: |
+         meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild --num-processes 2 -t 2
+
+    - name: Run unit tests
+      if: ${{ matrix.build == 'cmake' }}
+      run: |
+         ctest --output-on-failure --parallel 2
+      working-directory: ${{ env.BUILD_DIR }}
+
+    - name: Create coverage report
+      if: ${{ matrix.build == 'meson' && matrix.build-type == 'coverage' }}
+      run:
+         ninja -C ${{ env.BUILD_DIR }} coverage
+
+    - name: Install project
+      run: |
+        ninja -C ${{ env.BUILD_DIR }} install
+        echo "QCXMS_PREFIX=$PWD/_dist" >> $GITHUB_ENV
+
+    - name: Create package
+      if: ${{ matrix.build == 'meson' }}
+      run: |
+        tar cvf ${{ env.OUTPUT }} _dist
+        xz -T0 ${{ env.OUTPUT }}
+        echo "QCXMS_OUTPUT=${{ env.OUTPUT }}.xz" >> $GITHUB_ENV
+      env:
+        OUTPUT: qcxms-${{ matrix.compiler }}-${{ matrix.version }}-${{ matrix.os }}.tar
+
+    - name: Upload package
+      if: ${{ matrix.build == 'meson' && matrix.build-type != 'coverage' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.QCXMS_OUTPUT }}
+        path: ${{ env.QCXMS_OUTPUT }}
+
+    - name: Upload coverage report
+      if: ${{ matrix.build == 'meson' && matrix.build-type == 'coverage' }}
+      uses: codecov/codecov-action@v1

--- a/subprojects/dftd3.wrap
+++ b/subprojects/dftd3.wrap
@@ -1,4 +1,0 @@
-[wrap-git]
-directory = dftd3
-url = https://github.com/awvwgk/simple-dftd3
-revision = head

--- a/subprojects/dftd4.wrap
+++ b/subprojects/dftd4.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = dftd4
 url = https://github.com/dftd4/dftd4
-revision = head
+revision = v3.3.0

--- a/subprojects/mstore.wrap
+++ b/subprojects/mstore.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = mstore
 url = https://github.com/grimme-lab/mstore
-revision = v0.1.2
+revision = v0.2.0

--- a/subprojects/multicharge.wrap
+++ b/subprojects/multicharge.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = multicharge
 url = https://github.com/grimme-lab/multicharge
-revision = v0.1.1
+revision = v0.1.2

--- a/subprojects/s-dftd3.wrap
+++ b/subprojects/s-dftd3.wrap
@@ -1,2 +1,4 @@
-[wrap-redirect]
-filename = tblite/subprojects/s-dftd3.wrap
+[wrap-git]
+directory = s-dftd3
+url = https://github.com/awvwgk/simple-dftd3
+revision = head

--- a/subprojects/toml-f.wrap
+++ b/subprojects/toml-f.wrap
@@ -1,2 +1,4 @@
-[wrap-redirect]
-filename = tblite/subprojects/toml-f.wrap
+[wrap-git]
+directory = toml-f
+url = https://github.com/toml-f/toml-f
+revision = v0.2.2


### PR DESCRIPTION
Tests Intel oneAPI 2021.3.0 on Ubuntu 20.04, also includes paths to expand testing to GCC or MacOS/Windows later.

See https://github.com/awvwgk/QCxMS/runs/3266164290 for an example run with this workflow.