### PR TITLE
Allow compiling QCxMS with GCC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,19 @@ jobs:
         compiler: [intel]
         version: [2021]
 
+        include:
+          - os: ubuntu-latest
+            build: meson
+            build-type: debug
+            compiler: gnu
+            version: 11
+
+          - os: ubuntu-latest
+            build: meson
+            build-type: debug
+            compiler: gnu
+            version: 9
+
     env:
       FC: ${{ matrix.compiler == 'intel' && 'ifort' || 'gfortran' }}
       CC: ${{ matrix.compiler == 'intel' && 'icc' || 'gcc' }}
@@ -184,7 +197,7 @@ jobs:
     - name: Run unit tests
       if: ${{ matrix.build == 'meson' }}
       run: |
-         meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild --num-processes 2 -t 2
+         meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild --num-processes 1 -t 2
 
     - name: Run unit tests
       if: ${{ matrix.build == 'cmake' }}

--- a/config/meson.build
+++ b/config/meson.build
@@ -11,7 +11,6 @@ if fc_id == 'gcc'
     '-fbacktrace',
     language: 'fortran',
   )
-  error('This project does not support compilation with GCC yet')
 elif fc_id == 'intel'
   add_project_arguments(
     '-traceback',

--- a/config/meson.build
+++ b/config/meson.build
@@ -11,6 +11,9 @@ if fc_id == 'gcc'
     '-fbacktrace',
     language: 'fortran',
   )
+  if fc.version().version_compare('<8')
+    error('GCC version 8 or higher is required.')
+  endif
 elif fc_id == 'intel'
   add_project_arguments(
     '-traceback',

--- a/config/meson.build
+++ b/config/meson.build
@@ -97,46 +97,26 @@ else
   exe_deps += blas_dep
 endif
 
-# Look for tool-chain library as external dependency
-mctc_dep = dependency('mctc-lib', required: false, static: static)
-if not mctc_dep.found()
-  # Create the tool chain library as subproject
-  mctc_prj = subproject(
-    'mctc-lib',
-    version: '>=0.2',
-    default_options: [
-      'default_library=static',
-    ],
-  )
-  mctc_dep = mctc_prj.get_variable('mctc_dep')
-
-  if install
-    install_data(
-      mctc_prj.get_variable('mctc_lic'),
-      install_dir: get_option('datadir')/'licenses'/meson.project_name()/'mctc-lib'
-    )
-  endif
-endif
+# Create the tool chain library as subproject
+mctc_dep = dependency(
+  'mctc-lib',
+  version: '>=0.2',
+  fallback: ['mctc-lib', 'mctc_dep'],
+  default_options: ['default_library=static'],
+  static: static,
+)
 exe_deps += mctc_dep
 
-# Look tight-binding framework as external dependency
-tblite_dep = dependency('tblite', required: false, static: static)
-if not tblite_dep.found()
-  # Create the tight-binding framework as subproject
-  tblite_prj = subproject(
-    'tblite',
-    version: '>=0.1',
-    default_options: [
-      'default_library=static',
-    ],
-  )
-  tblite_dep = tblite_prj.get_variable('tblite_dep')
-
-  if install
-    install_data(
-      tblite_prj.get_variable('tblite_lic'),
-      install_dir: get_option('datadir')/'licenses'/meson.project_name()/'tblite'
-    )
-  endif
-endif
+# Create the tight-binding framework as subproject
+tblite_dep = dependency(
+  'tblite',
+  version: '>=0.1',
+  fallback: ['tblite', 'tblite_dep'],
+  default_options: ['default_library=static'],
+  static: static,
+)
 exe_deps += tblite_dep
+
+if tblite_dep.version().version_compare('>=0.2')
+  error('tblite version 0.2 or higher is not supported yet.')
+endif

--- a/src/egrad.f90
+++ b/src/egrad.f90
@@ -37,8 +37,6 @@ subroutine egrad(first,nuc,xyz,iat,chrg,spin,etemp,E,grad,qat,aspin,ECP,gradfail
    logical :: ECP
    logical :: ok,gradfail
 
-   external system
-
    disp   = 0
    E    = 0
    grad = 0

--- a/src/iniqm.f90
+++ b/src/iniqm.f90
@@ -80,8 +80,6 @@ module qcxms_iniqm
     
        character(len=20) :: atmp
     
-       external :: system
-    
        stat=0
        edum=0
     
@@ -258,8 +256,6 @@ module qcxms_iniqm
        integer :: stat
        character(len=:), allocatable :: output_name
     
-       external :: system
-    
        call electrons_amount(nat, iat, chrg, nel, nb, z)
     
     ! spec.f and regular IP/EA evaluations will use this input option
@@ -294,7 +290,7 @@ module qcxms_iniqm
           if(chrg == 0)then
              call qccall(0,'neutral.out')
           else
-             call system(0,'ion.out')
+             call qccall(0,'ion.out')
           endif
           call dftbenergy(energy)
        endif

--- a/src/main.F90
+++ b/src/main.F90
@@ -141,7 +141,6 @@ program QCxMS
   !logical gbsa ! set solvation model
 
   intrinsic :: get_command_argument
-  external  :: system
 
   interface
     function calc_ECOM(beta,e_kin) result(E_COM)
@@ -338,7 +337,12 @@ program QCxMS
   call setetemp(1,-1.0d0,betemp)
 
   ! ini RNDs
+#ifdef __INTEL_COMPILER
   call random_seed (put=iseed)
+#else
+  ! FIXME: this is probably not the right way to do this
+  call random_seed (put=spread(iseed(1), 1, 8))
+#endif
   call random_number(randx)
 
   ! for GS every n steps a struc. is used later for production, i.e.

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,5 +55,5 @@ srcs += files(
 )
 
 prog += files(
-  'main.f90',
+  'main.F90',
 )

--- a/src/mo_spec.f90
+++ b/src/mo_spec.f90
@@ -50,12 +50,12 @@ module qcxms_mo_spec
           ! USE ORCA
            write(*,*) 'Not yet working'
            ! eps has to be rewritten; changed it in readpopmo to emo and focc
-           stop
+           error stop
            write(*,*) 'doing DFT for MO spectrum for M ...'
            call eqm(3,nat,xyz,iat,mchrg,-1,0.0_wp,.false.,idum,energy,nel,nb,ECP,spec_calc)
            call system('rm -f ORCA.INPUT.prop')
            call system('mv neutral.out qcxms.Mspec')
-           if(abs(energy).lt.1.d-8.or.idum.ne.1) stop'QC initialization error'
+           if(abs(energy).lt.1.d-8.or.idum.ne.1) error stop 'QC initialization error'
            call geteps('qcxms.Mspec',nat,iat,mchrg,eps,mopop,ncore,ihomo,nb)
            emo (1:ihomo) = eps(1,1:ihomo)
 
@@ -64,7 +64,7 @@ module qcxms_mo_spec
            write(*,*) 'doing XTB for MO spectrum for M ...'
            call eqm(7,nat,xyz,iat,mchrg,-1,0.0_wp,.false.,idum,energy,nel,nb,ECP,spec_calc)
            call system('mv neutral.out qcxms.Mspec.xtb')
-           if(abs(energy).lt.1.d-8.or.idum.ne.1) stop'QC initialization error'
+           if(abs(energy).lt.1.d-8.or.idum.ne.1) error stop 'QC initialization error'
            call readpopmo(nat,nao,ihomo,emo,focc,mopop)
            
         ! USE XTB2 (default for everything else)
@@ -72,7 +72,7 @@ module qcxms_mo_spec
            write(*,*) 'doing XTB2 for MO spectrum for M ...'
            call eqm(8,nat,xyz,iat,mchrg,-1,0.0_wp,.false.,idum,energy,nel,nb,ECP,spec_calc)
            call system('mv neutral.out qcxms.Mspec.xtb2')
-           if(abs(energy).lt.1.d-8.or.idum.ne.1) stop'QC initialization error'
+           if(abs(energy).lt.1.d-8.or.idum.ne.1) error stop 'QC initialization error'
            call readpopmo(nat,nao,ihomo,emo,focc,mopop)
         endif
 
@@ -107,7 +107,7 @@ module qcxms_mo_spec
         write(*,'('' alpha/beta '',10F8.2)')pmo(1:ihomo)
      endif
 
-     if (emo(ihomo)-emo(1).lt.1.0) stop 'weird epsilons'
+     if (emo(ihomo)-emo(1).lt.1.0) error stop 'weird epsilons'
 
      emo =(-1.0_wp) * emo * evtoau  ! convert to neg. and au
 

--- a/src/msindo.f90
+++ b/src/msindo.f90
@@ -24,8 +24,6 @@ module qcxms_use_msindo
   
      logical :: first
   
-     external system
-  
      if(spin.eq.0) call getspin(nat,ic,chrg,spin)
   
      cyc=200

--- a/src/orca.f90
+++ b/src/orca.f90
@@ -60,28 +60,28 @@ module qcxms_use_orca
         open(file='ORCA.INPUT', newunit=io_orca)
 
      ! hybrid vs other funcs.... nat is number of atoms
-        if ( func <= 4 .and. nat < 60 .and. noconv ==  .false. ) then
+        if ( func <= 4 .and. nat < 60 .and. .not.noconv ) then
            write(io_orca,'(''! CONV SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func  ==  7 .and. nat < 60 .and. noconv ==  .false.) then
+        elseif ( func  ==  7 .and. nat < 60 .and. .not.noconv ) then
            write(io_orca,'(''! CONV SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func  ==  8 .and. nat < 60 .and. noconv  ==  .false.) then
+        elseif ( func  ==  8 .and. nat < 60 .and. .not.noconv ) then
            write(io_orca,'(''! CONV SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func  ==  9 .and. nat < 60 .and. noconv  ==  .false.) then
+        elseif ( func  ==  9 .and. nat < 60 .and. .not.noconv ) then
            write(io_orca,'(''! CONV SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func <= 4 .and. noconv ==  .True.)then
+        elseif ( func <= 4 .and. noconv)then
            write(io_orca,'(''! DIRECT SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func  ==  7 .and. noconv ==  .True.) then
+        elseif ( func  ==  7 .and. noconv) then
            write(io_orca,'(''! DIRECT SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func  ==  8 .and. noconv ==  .True.) then
+        elseif ( func  ==  8 .and. noconv) then
            write(io_orca,'(''! DIRECT SMALLPRINT NORI NOSOSCF'')')
 
-        elseif ( func  ==  9 .and. noconv ==  .True.) then
+        elseif ( func  ==  9 .and. noconv) then
            write(io_orca,'(''! DIRECT SMALLPRINT NORI NOSOSCF'')')
 
         ! RI
@@ -104,9 +104,9 @@ module qcxms_use_orca
         endif
 
         ! IF ECP true
-        if (ecp  ==  .true. .and. func /= 14)then
+        if (ecp .and. func /= 14)then
            write(io_orca,'(''! ecp('',a,'')'')')trim(basis(bas))
-        elseif(ecp  ==  .true. .and. func  ==  14)then
+        elseif(ecp .and. func  ==  14)then
            write(io_orca,'(''! ecp(def2-mSVP)'')')
         endif
 
@@ -344,7 +344,6 @@ module qcxms_use_orca
    
    integer :: line
    character(len=80) :: command
-   external :: system
    
    if(line >= 10000)stop 'error 1 inside copyorc'
    

--- a/src/tm.f90
+++ b/src/tm.f90
@@ -13,7 +13,6 @@ module qcxms_use_turbomole
      integer  :: nat,i,j
      integer  :: nn,io_grad
      real(wp) :: g(3,nat),xx(10),edum,chrg(nat),spin(nat)
-     external :: system
   
      open(file='gradient',newunit=io_grad)
      i=0
@@ -53,7 +52,7 @@ module qcxms_use_turbomole
      open(file='job.last',newunit=io_grad)
      do 
        read(io_grad,'(a)',iostat=iocheck)line
-       if (iocheck > 0) stop 'Something is wrong in tm.f90. Exiting...'
+       if (iocheck > 0) error stop 'Something is wrong in tm.f90. Exiting...'
        if( iocheck < 0) exit
   
        if(index(line,'atomic populations from total density:').ne.0)then
@@ -107,7 +106,6 @@ module qcxms_use_turbomole
   subroutine setfermi(temp)
      real(wp) :: temp
      character(len=80) :: atmp
-     external :: system
   
   !      write(atmp,'(''$fermi tmstrt='',F8.1,'' tmend='',F8.1)')temp,temp
      write(atmp,'(''$fermi tmstrt='',F8.1,'' hlcrt=-1.0E0  stop=1.E-99 addTS noerf '')')temp
@@ -124,8 +122,6 @@ module qcxms_use_turbomole
   
   subroutine dscftm
 
-     external :: system
-  
      if(shell.eq.1) call system('( /usr/local/bin/ridft >  job.last ) > & /dev/null')
      if(shell.eq.2) call system('( ridft >  job.last  2>   /dev/null')
   
@@ -134,8 +130,6 @@ module qcxms_use_turbomole
   
   subroutine gradtm
 
-     external :: system
-  
   !     if(shell.eq.1) call system('( grad >> job.last ) > & /dev/null')
   !     if(shell.eq.2) call system('  grad >> job.last  2>   /dev/null')
   
@@ -157,8 +151,6 @@ module qcxms_use_turbomole
      character(len=30) :: basi
   
      logical :: strange_elem
-  
-     external :: system
   
   ! set strange element to false
      strange_elem=.false.
@@ -268,7 +260,7 @@ module qcxms_use_turbomole
         call system("echo '$end              '   >> control")
   !     PBE12 and PBE38 do not work
      elseif(func.eq.2.or.func.eq.3.or.func.eq.9.or.func.eq.13) then
-        stop'PBE12/PBE38/B3PW91/REVPBE not implemented with Turbomole.'
+        error stop 'PBE12/PBE38/B3PW91/REVPBE not implemented with Turbomole.'
   !     M062X without dispersion!
      elseif(func.eq.4) then
         call system("echo ' functional m062x'   >> control")
@@ -380,9 +372,8 @@ module qcxms_use_turbomole
   subroutine copytm(it)
      integer  :: it
      character(len=80) :: fname
-     external :: system
   
-     if(it.ge.10000)stop 'error 1 inside copytm'
+     if(it.ge.10000)error stop 'error 1 inside copytm'
   
      call system('cp coord coord.original')
   
@@ -458,7 +449,7 @@ module qcxms_use_turbomole
         return
      endif
   
-     stop 'error 2 inside copytm'
+     error stop 'error 2 inside copytm'
   
   end subroutine
   
@@ -470,9 +461,8 @@ module qcxms_use_turbomole
   
      integer  :: it
      character(len=80) :: fname
-     external :: system
   
-     if(it.ge.10000)stop 'error 1 inside copytm'
+     if(it.ge.10000)error stop 'error 1 inside copytm'
   
      call system('cp coord coord.original')
   
@@ -500,7 +490,7 @@ module qcxms_use_turbomole
         return
      endif
   
-     stop 'error 2 inside copytm'
+     error stop 'error 2 inside copytm'
   
   end subroutine
 

--- a/src/utility.f90
+++ b/src/utility.f90
@@ -90,8 +90,6 @@ module qcxms_utility
       character(len=* ) :: fout
       character(len=80) :: atmp
    
-      external system
-   
       calls = calls + 1
    
    ! DFTB+
@@ -150,7 +148,6 @@ module qcxms_utility
    
       integer  :: it
       character(len=80) :: fname
-      external :: system
    
       if(it.lt.10000)write(fname,'(''mkdir TMPQCXMS/TMP.'',i4)')it
       if(it.lt.1000) write(fname,'(''mkdir TMPQCXMS/TMP.'',i3)')it
@@ -167,7 +164,6 @@ module qcxms_utility
    
       integer :: it
       character(len=80) :: fname
-      external system
    
       if(it.ge.10000)stop 'error 1 inside copytb'
    
@@ -214,7 +210,6 @@ module qcxms_utility
    
       integer :: it
       character(len=80) :: fname
-      external system
    
       if(it.ge.10000)stop 'error 1 inside copymop'
    
@@ -269,7 +264,6 @@ module qcxms_utility
    
       integer :: it
       character(len=80) :: fname
-      external system
    
       if(it.ge.10000)stop 'error 1 inside copymsindo'
    

--- a/subprojects/tblite.wrap
+++ b/subprojects/tblite.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = tblite
 url = https://github.com/awvwgk/tblite
-revision = head
+revision = v0.1.0


### PR DESCRIPTION
Fixes some issues which are specific to GCC

- build checked with GCC 11.1.0
- enable workflow for GCC 11 and GCC 9 on Ubuntu 20.04
- use error stop to get non-zero exit codes in case of failures
- fix a wrong call to system rather than qccall in iniqm
- longer seed required for random number generator in GFortran runtime

Probably needs one additional manual check regarding performance and correctness against an Intel compiled binary before merging.