### PR TITLE
Set ORCA default settings when using ORCA 5

### DIFF
--- a/src/analyse.f90
+++ b/src/analyse.f90
@@ -161,7 +161,8 @@ subroutine analyse(iprog,nuc,iat,iatf,axyz,list,nfrag,etemp,fragip, mchrg, &
     endif
           
   else
-            bas = 3           !SV(P)
+            !bas = 3           !SV(P)
+            bas = isave
     if(ecp) bas = 9           !def2-SV(P)
   endif
   

--- a/src/orca.f90
+++ b/src/orca.f90
@@ -58,7 +58,9 @@ module qcxms_use_orca
 
         ! open and write to ORCA input file
         open(file='ORCA.INPUT', newunit=io_orca)
-
+        
+        ! settings for ORCA 4, for ORCA 5 default settings should be fine
+        if ( orca_version == 4 ) then 
      ! hybrid vs other funcs.... nat is number of atoms
         if ( func <= 4 .and. nat < 60 .and. .not. noconv ) then
          !if ( No_eTemp ) then
@@ -93,11 +95,14 @@ module qcxms_use_orca
            write(io_orca,'(''!  DEF2/J SMALLPRINT NOSOSCF'')')
         endif
 
+        else
+           write(io_orca,'(''!  DEF2/J SMALLPRINT'')')
+        end if
      
         ! Set mayer and finalgrid
         if ( orca_version == 4 ) write(io_orca,'(''! NOFINALGRID NOMAYER'')')
         if ( orca_version == 5 ) then
-           write(io_orca,'(''! NOFINALGRIDX NOMAYER'')')
+           write(io_orca,'(''! NOMAYER'')')
        endif
      
         write(io_orca,'(''! UHF'')')

--- a/src/version.f90
+++ b/src/version.f90
@@ -7,14 +7,14 @@ contains
      integer,intent(in) :: i
      character(len=:), allocatable  :: line
 
-     line ='Sep 20 18:00:00 CEST 2022 '
+     line ='May 30 13:30:00 CEST 2023 '
 
      if (i.eq.0)then
-       write(*,' (22x,''*'',18x,''V5.2.1'',18x,'' *'')'  )
+       write(*,' (22x,''*'',18x,''V5.2.2'',18x,'' *'')'  )
      endif
      if (i.eq.1)  write(*,' (22x,''*        '',(a)''         *'')'     ) line
-     if (i.eq.2)  write(*,' (22x,''--- QCxMS V5.2.1'',(a)'' ---'')') line
-     if (i.eq.33) write(33,'(22x,''--- QCxMS V5.2.1'',(a)'' ---'')') line
+     if (i.eq.2)  write(*,' (22x,''--- QCxMS V5.2.2'',(a)'' ---'')') line
+     if (i.eq.33) write(33,'(22x,''--- QCxMS V5.2.2'',(a)'' ---'')') line
 
    end subroutine version
 


### PR DESCRIPTION
The old settings led to very slow calculations, when using hybrid DFT. With ORCA 5, the RIJCOSX approximation is accurate and should be used. Additionally, convergence problems which may be caused by using the old integral routines CONV in ORCA are avoided from now on by removing this keyword.